### PR TITLE
Switch ruby styleguide to recommend 'fat arrow' hash syntax

### DIFF
--- a/ruby.md
+++ b/ruby.md
@@ -564,23 +564,23 @@
     hash = {"one" => 1, "two" => 2, "three" => 3}
 
     # good
-    hash = {one: 1, two: 2, three: 3}
+    hash = {:one => 1, :two => 2, :three => 3}
     ```
 
-- Use Ruby 1.9 syntax for symbolic hash keys. This includes method calls.
+- Use fat arrows (a.k.a hashrocket) syntax for symbolic hash keys. This includes method calls.
 
     ```ruby
     # bad
-    hash = {:one => 1, :two => 2}
-
-    # good
     hash = {one: 1, two: 2}
 
+    # good
+    hash = {:one => 1, :two => 2}
+
     # bad
-    some_method :one => 1, :two => 2
+    some_method one: 1, two: 2
 
     # good
-    some_method one: 1, two: 2
+    some_method :one => 1, :two => 2
     ```
 
 ## Strings


### PR DESCRIPTION
I think the fat arrow (a.k.a. hash rocket) hash syntax is better than the new 1.9 hash syntax

``` ruby
#bad
hash = {foo: :bar}

#good
hash = {:foo => :bar}
```

My reasoning is as follows:

The new 1.9 syntax can only be used for hashes with Symbol literals as the keys.  All other usage has to use the fat arrow syntax.

``` ruby
variable = :foo
hash = {symbol: 1, "string" => 2, 42 => 3, true => 4, variable => 5}
# => {:symbol=>1, "string"=>2, 42=>3, true=>4, :foo=>5}
```

Note: `Hash#inspect` uses the fat arrow syntax.

The 1.9 syntax cannot be used if the symbol name matches a ruby keyword.  e.g.:

``` ruby
# This will cause a syntax error because if is a keyword
validates :password, presence: { if: :password_required? }, confirmation: true
```

It introduces a second way of writing symbols, which makes it harder to read.  Compare the above validates example with:

``` ruby
validates :password, :presence => { :if => :password_required? }, :confirmation => true
```

In general, the fat arrow syntax is much more consistent than the new 1.9 syntax.

I haven't really seen a reasoned argument for using the 1.9 syntax.

Another opinion: http://www.michaelxavier.net/posts/2011-07-01-I-Dont-Understand-The-New-Ruby-Hash-Syntax.html
