### PR TITLE
Specify that we should lock on specific gem versions

### DIFF
--- a/ruby.md
+++ b/ruby.md
@@ -4,6 +4,14 @@
 
 -   Write for Ruby 1.9.
 
+-   Lock dependencies in Gemfiles to specific versions.
+
+    ```gem 'rails', '3.2.7'```
+
+    not
+
+    ```gem 'rails', '~> 3.2.7'```
+
 -   Use soft-tabs with a two-space indent.
 
 -   Keep lines fewer than 80 characters.


### PR DESCRIPTION
We aren't confident that all of our dependencies will follow sensible versioning practices and so will need to do some review of all new versions. Locking them down protects against minor changes creeping in unintentionally and/or exposing ourselves to new security issues this way.
