### PR TITLE
Suggest a more permissive use of string quoting.

### DIFF
--- a/ruby.md
+++ b/ruby.md
@@ -606,7 +606,7 @@
 -   Try not to mix up single-quoted and double-quoted strings within a file:
     it can make the code harder to read. *Definitely* don't mix up single-quoted
     and double-quoted strings within a method. If in doubt, use double-quoted
-    strings.
+    strings, because you’ll probably need to use interpolation somewhere.
 
 -   Avoid using `String#+` when you need to construct large data chunks.
     Instead, use `String#<<`. Concatenation mutates the string instance


### PR DESCRIPTION
Because there’s very little benefit to arguments in pull requests about whether to use single– or double-quoted strings. Let’s take this back to the problem we’re trying to avoid, namely hard-to-understand code.
