### PR TITLE
Tidying up redundant HTML, CSS & JS docs

### DIFF
--- a/css.md
+++ b/css.md
@@ -1,29 +1,5 @@
 ## CSS Coding Style
 
--   Group attributes for elements by property type. Separate each group by a blank link. Follow this order where possible: display, positioning, dimensions/box model, text & font styles, colours & decoration.
-    
-    For example:
-
-    ```css
-    .my-selector {
-      display: block;
-      
-      position: relative;
-      top: 0;
-      left: 2.4em;
-      
-      width: 40em; height: 60em;
-      margin: 0 auto;
-      padding: 2em 4em 6em 2em;
-      
-      font-size: 1.9em;
-      line-height: 2.5em;
-      text-decoration: underline;
-      
-      color: #333;
-      background-color: #999;
-    }
-
 -   Use comments to divide and clarify what groups of declarations are for
 
 -   Dimensions: use ems to 2 decimal places to [support IE6 and 7](http://destination-code.blogspot.co.uk/2008/10/font-size-relative-length-unit-em.html)
@@ -40,27 +16,4 @@
     border-radius: xx;
     ```
 
-## Our friend Internet Explorer
-
-For targeting IE8 and below use a class of `lte-ie8`, then add specific hacks for IE7 with an `*` and for IE6 with an `_`.
-
-For example:
-
-```css
-.foo {
-  color: black;
-}
-
-.lte-ie8 .foo {
-  color: green; /* IE8 and older */
-  *color: blue; /* IE7 and older */
-  _color: red; /* IE6 and older */
-}
-```
-
-(stolen from http://mathiasbynens.be/notes/safe-css-hacks)
-
-
-## REM sizing - why not?
-
-Because [IE6, 7, and 8](http://caniuse.com/rem) don't support them, and mixing pixels with rems to get cross browser support is too much redundant code.
+    Before using any such features, check there isn't an existing mixin for it in the [govuk_frontend_toolkit](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_css3.scss). If there isn't one, consider adding it in the existing style.

--- a/html.md
+++ b/html.md
@@ -22,23 +22,39 @@ Example:
 
     <header role="banner"></header>
 
-
 The following roles map directly to HTML5 sectioning elements:
 
-* `role="complementary"` maps to the `<article>` element
+* `role="main"` maps to the `<main>` element
+* `role="complementary"` maps to the `<aside>` element
 * `role="contentinfo"` maps to the `<footer>` element
 * `role="navigation"` maps to the `<nav>` element
+
+For a more comprehensive guide to the mapping of roles to HTML5 sectioning elements read this [guide](http://blog.paciellogroup.com/2013/02/using-wai-aria-landmarks-2013/) from the Paciello Group.
 
 The following landmark roles don't map to HTML5 elements, but are
 still good to use:
 
 * `role="search"`
-* `role="main"`
 * `role="application"`
 
 [Demo of how landmark roles help screen reader users](http://tink.co.uk/2011/07/how-do-aria-landmark-roles-help-screen-reader-users/)
 
+## Main content
+
+The `<main>` tag should be used to identify the main content of your page. Support for it is still marginal so ensure to add the `role="main"` attribute.
+
+## Sectioned content
+
+When using the `<section>` tag, add an `aria-labelledby` attribute linking to the id of the heading that identifies that section.
+
+Example:
+
+    <section labelledby="advice">
+      <h1 id="advice">Help and advice</h1>
+
 ## Navigational elements
+
+The detail of using the `<nav>` tag is covered in this [blog post](https://insidegovuk.blog.gov.uk/2013/07/03/rethinking-navigation/).
 
 ### Emphasis
 

--- a/js.md
+++ b/js.md
@@ -15,3 +15,7 @@ E.g `js-hidden`, `js-tab` etc. This makes it completely transparent what the cla
 ## Don't apply styles directly inside Javascript
 
 You should only ever apply CSS classes and style from there. Otherwise you risk clobbering user stylesheets and mixing concerns across different code bases. Also see the previous point.
+
+## Strict mode
+
+Add the `"use strict";` statement to the top of your scripts to enable [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions_and_function_scope/Strict_mode).


### PR DESCRIPTION
Much of the CSS advice was made redundant by various development decisions (and the toolkit).
The advice over usage of HTML5 tags and ARIA needed updating.
Writing JavaScript in [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions_and_function_scope/Strict_mode) is already being applied across many projects and will ensure our code is more robust.
