### PR TITLE
Remove rule about parentheses in Ruby methods.

### DIFF
--- a/ruby.md
+++ b/ruby.md
@@ -328,15 +328,6 @@
     scripts is discouraged. Prefer long form versions such as
     `$PROGRAM_NAME`.
 
--   Use parentheses when using the return value of a method. Omit them
-    otherwise, unless necessary due to syntax edge cases.
-
-    ```ruby
-    value = calculate_something(a, b)
-
-    do_something a, b
-    ```
-
 -   Never put a space between a method name and the opening parenthesis.
 
     ```ruby


### PR DESCRIPTION
The best rule about parentheses is usually to do whatever is most readable and understandable in each individual case.
