### PR TITLE
Clarify Ruby example demonstrating chained blocks.

### DIFF
--- a/ruby.md
+++ b/ruby.md
@@ -246,7 +246,7 @@
     # bad
     names.select do |name|
       name.start_with?("S")
-    end.map { |name| name.upcase }
+    end.map(&:upcase)
 
     # good
     names.select { |name| name.start_with?("S") }.map(&:upcase)


### PR DESCRIPTION
It used to have a different style for the chained `map`, as well as chaining onto the `do...end` block. This made it less clear what the example was supposed to demonstrate.
