### PR TITLE
Add guidance for linking to issue trackers from commit messages

### DIFF
--- a/git.md
+++ b/git.md
@@ -37,6 +37,19 @@ IE 6 was doing foo, so we need to do X.
 See http://example.com/why-is-this-broken for more details.
 ```
 
+#### Links to issue trackers
+
+A link to a ticket in an issue tracker should not be seen as an alternative to
+writing a commit message.
+
+While a link can add some extra context for people reviewing
+a pull-request, the commit message should stand on its own.  There's no guarantee that
+the link will continue to work in the future when someone is looking through the commit
+history to understand why a change was made.
+
+If you are adding a link to a publicly viewable repository, ensure that the linked
+ticket is publicly viewable (and likely to remain so).
+
 
 ### Structure
 


### PR DESCRIPTION
There have been some commit messages recently that only include a link to an issue tracker.  Let's add some guidance to discourage this practice.
