### PR TITLE
Change syntax highlighting for SASS examples to SCSS

### DIFF
--- a/css.md
+++ b/css.md
@@ -82,7 +82,7 @@ future when the vendor prefixed versions aren't needed.
 
 * Always define parent reference selectors before defining child selectors
 
-  ```sass
+  ```scss
   // Bad
   a {
     color: red;
@@ -117,7 +117,7 @@ future when the vendor prefixed versions aren't needed.
 
 * Where possible rather than repeating selectors nest blocks together
 
-  ```sass
+  ```scss
   // Bad
   .header h1 {
     font-weight: bold;


### PR DESCRIPTION
As these are examples in the SCSS syntax. Was causing error highlighting of curly brackets and semi colons.
