### PR TITLE
Add GOV.UK README guidance

### DIFF
--- a/use-of-READMEs.md
+++ b/use-of-READMEs.md
@@ -62,12 +62,12 @@ Keep this section limited to core endpoints - if the app is complex link out to 
 
 ```
 
-## Things this template achieves
+## Benefits of using this template
 
-- Is consistent
-- Is scannable
-- Functionality is shown in screenshots and links to live services
-- Has quick start information for new developers or interested third parties
+- it is consistent
+- it is scannable
+- functionality is shown in screenshots and links to live services
+- it has quick start information for new developers or interested third parties
 
 ## Things we shouldn't put in the README
 


### PR DESCRIPTION
Add a first cut at guidance on how to structure a README for a GOV.UK public project, including examples and justification.

This was produced with @alext, @annashipman, @dcarley. @dsingleton, @evilstreak and @jamiecobbett.
