### PR TITLE
Use 'backing service' instead of 'primitive'

### DIFF
--- a/use-of-READMEs.md
+++ b/use-of-READMEs.md
@@ -33,7 +33,7 @@ Document if app is Ruby etc and whether it uses Bundler etc.
 ### Dependencies
 
 - [alphagov/other-repo]() - provides some downstream service
-- [redis]() - provides a primitive
+- [redis]() - provides a backing service for work queues
 
 ### Running the application
 


### PR DESCRIPTION
There's prior art in places like http://12factor.net/backing-services, it's clearer language, and it allowed me to add some extra context to the example.
