### PR TITLE
Make 'technical documentation' example intro better

### DIFF
--- a/use-of-READMEs.md
+++ b/use-of-READMEs.md
@@ -28,7 +28,11 @@ One paragraph description and purpose.
 
 ## Technical documentation
 
-Document if app is Ruby etc and whether it uses Bundler etc.
+Write a single paragraph including a general technical overview of the app.
+Example:
+
+This is a Ruby on Rails application that maps RESTful URLs onto a persistence
+layer. It's only presented as an internal API and doesn't face public users.
 
 ### Dependencies
 


### PR DESCRIPTION
This adds an example of the expected output and sets clearer expectations about what we'd like to see there.
