### PR TITLE
Change "MIT Licence" to "MIT License"

### DIFF
--- a/use-of-READMEs.md
+++ b/use-of-READMEs.md
@@ -61,7 +61,7 @@ Keep this section limited to core endpoints - if the app is complex link out to 
 
 ## Licence
 
-[MIT Licence](LICENCE)
+[MIT License](LICENCE)
 
 ## Versioning policy (for Gems only)
 


### PR DESCRIPTION
The MIT License is an American licence, and as such we can't refer to it as the MIT Licence because that is not a thing that exists.

For consistency I'd prefer that we then use "license" everywhere, but I could be persuaded either way on that.
