### PR TITLE
[remove_tabs_from_yaml] Remove TABs from Yaml

### DIFF
--- a/ruby-styleguide/rubocop/other-lint.yml
+++ b/ruby-styleguide/rubocop/other-lint.yml
@@ -1,7 +1,7 @@
 AmbiguousOperator:
   Description: >-
-     Checks for ambiguous operators in the first argument of a
-     method invocation without parentheses.
+    Checks for ambiguous operators in the first argument of a
+    method invocation without parentheses.
   Enabled: false
 
 AmbiguousRegexpLiteral:
@@ -52,8 +52,8 @@ HandleExceptions:
 
 InvalidCharacterLiteral:
   Description: >-
-		 Checks for invalid character literals with a non-escaped
-		 whitespace character.
+    Checks for invalid character literals with a non-escaped
+    whitespace character.
   Enabled: false
 
 LiteralInCondition:
@@ -66,32 +66,32 @@ LiteralInInterpolation:
 
 Loop:
   Description: >-
-		 Use Kernel#loop with break rather than begin/end/until or
-		 begin/end/while for post-loop tests.
+    Use Kernel#loop with break rather than begin/end/until or
+    begin/end/while for post-loop tests.
   Enabled: false
 
 ParenthesesAsGroupedExpression:
   Description: >-
-		 Checks for method calls with a space before the opening
-		 parenthesis.
+    Checks for method calls with a space before the opening
+    parenthesis.
   Enabled: false
 
 RequireParentheses:
   Description: >-
-		 Use parentheses in the method call to avoid confusion
-		 about precedence.
+    Use parentheses in the method call to avoid confusion
+    about precedence.
   Enabled: false
 
 ShadowingOuterLocalVariable:
   Description: >-
-		 Do not use the same name as outer local variable
-		 for block arguments or block local variables.
+    Do not use the same name as outer local variable
+    for block arguments or block local variables.
   Enabled: false
 
 SpaceBeforeFirstArg:
   Description: >-
-		 Put a space between a method name and the first argument
-		 in a method call without parentheses.
+    Put a space between a method name and the first argument
+    in a method call without parentheses.
   Enabled: false
 
 UnderscorePrefixedVariableName:


### PR DESCRIPTION
* Made yml consistently use spaces.
* Fixed an error that occurs when parsing the Yaml with Psych:

```
Found a tab character where an intendation space is expected while
scanning a block scalar at line 54 column 16
```
