### PR TITLE
Remove line length recommendation from ruby.md

### DIFF
--- a/ruby.md
+++ b/ruby.md
@@ -34,8 +34,6 @@ This styleguide is based on [GitHub's](https://github.com/styleguide/ruby).
 
 -   Use soft-tabs with a two-space indent. (*Tab,IndentationWidth,IndentationConsistency,BlockAlignment,ElseLayout,EndAlignment*)
 
--   Keep lines fewer than 80 characters. (*LineLength*)
-
 -   Never leave trailing whitespace, except: (*TrailingWhitespace,EmptyLines,EndOfLine*)
 
 -   Always leave a trailing newline in the file to keep compatibility with

--- a/ruby.md
+++ b/ruby.md
@@ -34,6 +34,8 @@ This styleguide is based on [GitHub's](https://github.com/styleguide/ruby).
 
 -   Use soft-tabs with a two-space indent. (*Tab,IndentationWidth,IndentationConsistency,BlockAlignment,ElseLayout,EndAlignment*)
 
+-   Keep lines fewer than 80 characters unless doing so makes the code more difficult to read (see [PR 7 in govuk-lint](https://github.com/alphagov/govuk-lint/pull/7) for more information). (*LineLength*)
+
 -   Never leave trailing whitespace, except: (*TrailingWhitespace,EmptyLines,EndOfLine*)
 
 -   Always leave a trailing newline in the file to keep compatibility with


### PR DESCRIPTION
Remove the recommendation that lines are kept to fewer than 80 characters.

We removed the line length check from Rubocop in govuk-lint PR 7[1] and it
feels as though this Styleguide and the Rubocop rules should be kept in sync.

[1]: https://github.com/alphagov/govuk-lint/pull/7