### PR TITLE
Spaces hash braces consistently with guide

### DIFF
--- a/ruby.md
+++ b/ruby.md
@@ -646,20 +646,20 @@ This styleguide is based on [GitHub's](https://github.com/styleguide/ruby).
 
     ```ruby
     # bad
-    hash = {"one" => 1, "two" => 2, "three" => 3}
+    hash = { "one" => 1, "two" => 2, "three" => 3 }
 
     # good
-    hash = {one: 1, two: 2, three: 3}
+    hash = { one: 1, two: 2, three: 3 }
     ```
 
 - Use Ruby 1.9 syntax for symbolic hash keys. This includes method calls. (*HashSyntax*)
 
     ```ruby
     # bad
-    hash = {:one => 1, :two => 2}
+    hash = { :one => 1, :two => 2 }
 
     # good
-    hash = {one: 1, two: 2}
+    hash = { one: 1, two: 2 }
 
     # bad
     some_method :one => 1, :two => 2


### PR DESCRIPTION
This was conflicting with earlier advice on spacing around hash braces.