### PR TITLE
Edit Pull Request styleguide

### DIFF
--- a/pull-requests.md
+++ b/pull-requests.md
@@ -57,7 +57,8 @@ styleguide](/git.md#commit-messages).
   or while pairing (especially if they're less experienced).
 - If you're going to discuss some issues offline, please comment as such in the
   PR so that no-one merges it in the meantime - "A few issues here, going to
-  discuss offline" would be enough
+  discuss offline" would be enough. When conversation has taken place elsewhere,
+  summarise the conversation as a comment on the PR for the benefit of others.
 - If the code is good, or solves something in a clever way, *say
   so*. Call out individual bits of quality - it signposts good practice for
   others, and rewards the person submitting the request.
@@ -74,9 +75,6 @@ styleguide](/git.md#commit-messages).
   page because GitHub loses them if you rebase
 - If you're committed to reviewing the request through to merging or closing,
   assign the PR to yourself
-- If a conversation about a specific implementation happens off GitHub (eg in
-  Slack or in person), summarise the conversation as a comment on the PR for the
-  benefit of others
 - If something is a blocker to merging, make that explicit by stating that it's
   a blocker in a comment
 - Likewise, when commenting on things, state plainly whether the rest of the PR

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -52,14 +52,9 @@ styleguide](/git.md#commit-messages).
 
 - It is important to take time to review a pull request properly; the review
   stage is as important as writing the code in the first place
-
-If you're not sure how the individual wants their request reviewed, make an
-effort to contact them before starting - they may prefer some of the feedback to
-be done in person or while pairing (especially if they're less experienced). If
-some of the feedback is performed offline you should capture a summary of the
-output in a pull request comment so others can see it, but make sure the
-individual is happy with the summary first.
-
+- If you're not sure how the individual wants their request reviewed, ask them
+  before starting - they may prefer some of the feedback to be done in person
+  or while pairing (especially if they're less experienced).
 - If you're going to discuss some issues offline, please comment as such in the
   PR so that no-one merges it in the meantime - "A few issues here, going to
   discuss offline" would be enough

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -24,9 +24,9 @@ This is a pull requests style guide for working on GOV.UK.
 - Consider PRs to be all of the work - it's okay to have follow-up PRs for a
   feature if a set of changes are complete enough to go live
 
-## What should we do?
+## Guidance for each step
 
-Following is a rough workflow with guidance for each step.
+If you are not sure how to do any of this, please feel free to ask for help.
 
 ### Opening a request
 

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -61,8 +61,6 @@ code merged - here are some guidelines to help with that process:
 - If there are several PRs that you would like to be reviewed and merged together
   (eg frontend and backend changes, or endpoint and adapter changes), cross-link
   the PRs by referencing the other PR in a comment or the PR description
-- Use separate commits for formatting, refactoring, etc - change the
-  functionality, commit, then refactor
 
 ### Reviewing a request
 

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -39,8 +39,7 @@ That said, the PR description is there to aid the reviewer and to help get your
 code merged - here are some guidelines to help with that process:
 
 - Before opening the PR, make sure you're up to date with `master` so that your
-  changes are easier to merge (please ask for help if you're not sure how to do
-  this)
+  changes are easier to merge
 - Make the title of the PR scannable - this will ensure that it's easier for
   potential reviewers to notice
 - Summarise your changes in the description - this aids both the reviewer and

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -58,6 +58,9 @@ styleguide](/git.md#commit-messages).
 - If you're going to discuss some issues offline, please comment as such in the
   PR so that no-one merges it in the meantime - "A few issues here, going to
   discuss offline" would be enough
+- If the code is good, or solves something in a clever way, *say
+  so*. Call out individual bits of quality - it signposts good practice for
+  others, and rewards the person submitting the request.
 - Try running the code - even if the tests pass it might have bugs
 - Consider security when reviewing code, particularly where there is user input.
   The [basic security guidance](basic-security.md) might help.
@@ -81,9 +84,6 @@ styleguide](/git.md#commit-messages).
 - Ensure that any relevant documentation (`README` files, things in the `doc`
   folder) is up to date with the changes
 
-Don't forget that if the code is good, or solves something in a clever way, *say
-so*. Call out individual bits of quality - it signposts good practice for
-others, and rewards the person submitting the request.
 
 ### Addressing comments
 

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -61,9 +61,9 @@ styleguide](/git.md#commit-messages).
 - Try running the code - even if the tests pass it might have bugs
 - Consider security when reviewing code, particularly where there is user input.
   The [basic security guidance](basic-security.md) might help.
-- Definition of 'done' - if the PR adds value on its own but doesn't entirely
-  address the need/ticket merge and deploy it anyway. Any improvement is a good
-  improvement, and it keeps the code moving
+- Remember that a PR does not have to entirely solve the problem. If it adds
+  value on its own it is better to merge now rather than wait for the rest of
+  the changes required.
 - If you look at a PR but don't feel comfortable merging it please say what
   you've looked at or not so other reviewers know the request hasn't been
   properly reviewed

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -32,8 +32,8 @@ Following is a rough workflow with guidance for each step.
 
 The canonical description of changes should always be in the individual
 commits - Pull Requests are an artefact of GitHub, and we would lose that data
-if we switched away. So a good PR description is not an adequate substitute for
-the context and explanation provided by a good series of commits.
+if we switched away. Please refer to the [commit message
+styleguide](/git.md#commit-messages).
 
 That said, the PR description is there to aid the reviewer and to help get your
 code merged - here are some guidelines to help with that process:

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -67,8 +67,6 @@ styleguide](/git.md#commit-messages).
 - If you look at a PR but don't feel comfortable merging it please say what
   you've looked at or not so other reviewers know the request hasn't been
   properly reviewed
-- The same goes for small comments, email typo corrections - state clearly that
-  you didn't review the entire thing.
 - Always comment on individual lines in the full-file diff view, not on a commit
   page because GitHub loses them if you rebase
 - If you're committed to reviewing the request through to merging or closing,

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -50,32 +50,41 @@ styleguide](/git.md#commit-messages).
 
 ### Reviewing a request
 
+#### Guidelines for review
+
 - It is important to take time to review a pull request properly; the review
   stage is as important as writing the code in the first place
 - If you're not sure how the individual wants their request reviewed, ask them
   before starting - they may prefer some of the feedback to be done in person
   or while pairing (especially if they're less experienced).
+- If the code is good, or solves something in a clever way, *say
+  so*. Call out individual bits of quality - it signposts good practice for
+  others, and rewards the person submitting the request.
+- State what, if anything, is a blocker explicitly
+
+#### Communicate with others who may consider reviewing the PR
+
 - If you're going to discuss some issues offline, please comment as such in the
   PR so that no-one merges it in the meantime - "A few issues here, going to
   discuss offline" would be enough. When conversation has taken place elsewhere,
   summarise the conversation as a comment on the PR for the benefit of others.
-- If the code is good, or solves something in a clever way, *say
-  so*. Call out individual bits of quality - it signposts good practice for
-  others, and rewards the person submitting the request.
+- If you look at a PR but don't feel comfortable merging it please say what
+  you've looked at or not so other reviewers know the request hasn't been
+  properly reviewed.
+- If you're committed to reviewing the request through to merging or closing,
+  assign the PR to yourself
+
+
+#### Helpful things to consider while reviewing
+
 - Try running the code - even if the tests pass it might have bugs
 - Consider security when reviewing code, particularly where there is user input.
   The [basic security guidance](basic-security.md) might help.
 - Remember that a PR does not have to entirely solve the problem. If it adds
   value on its own it is better to merge now rather than wait for the rest of
   the changes required.
-- If you look at a PR but don't feel comfortable merging it please say what
-  you've looked at or not so other reviewers know the request hasn't been
-  properly reviewed.
 - Always comment on individual lines in the full-file diff view, not on a commit
   page because GitHub loses them if you rebase
-- If you're committed to reviewing the request through to merging or closing,
-  assign the PR to yourself
-- State what, if anything, is a blocker explicitly
 - Ensure that any relevant documentation (`README` files, things in the `doc`
   folder) is up to date with the changes
 

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -136,3 +136,8 @@ We sometimes receive pull requests from members of the public, and while we shou
 - Try and comment on the changed files rather than by commit as the notifications are easier to follow
 - If the contributor has not written a line in the CHANGELOG, then once their PR is merged, write a line to describe it.
 - Whether they have written the CHANGELOG entry or you do, please add a “Thank you @githubusername”. We don’t usually add CHANGELOG notes for documentation, but if that comes from an external source, add a documentation credit at the end to thank them.
+
+## Further reading
+
+- [Anna Shipman](https://github.com/annashipman) has written a useful blog post about [how to raise a good pull request](http://www.annashipman.co.uk/jfdi/good-pull-requests.html)
+- A great example of [a good pull request](https://github.com/alphagov/frontend/pull/784) raised by [Alice Bartlett](https://github.com/alicebartlett)

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -49,8 +49,6 @@ code merged - here are some guidelines to help with that process:
   the PR
 - Include information about the problem/user need/tracker ticket you're fixing
   to help summarise the issue
-- Suggest a way to review the request (commit by commit, whole diff, with
-  whitespace turned off etc.)
 - If the changes involve frontend code, we love screenshots!
 - If your changes contain some potentially contentious changes, pre-empt these
   by explaining why you went one way over another (for the benefit of the

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -30,37 +30,23 @@ If you are not sure how to do any of this, please feel free to ask for help.
 
 ### Opening a request
 
-The canonical description of changes should always be in the individual
+- Before opening the PR, make sure you're up to date with `master` so that your
+  changes are easier to merge
+- The title and description should help the reviewer. Make the title succinct
+  and descriptive, and then add detail in the description.
+- The description should summarise your changes and include useful links, eg to
+  a Pivotal ticket, ZenDesk ticket or related PR. If the changes involve
+  frontend code, we love screenshots!
+- When raising a PR, the title and description are emailed to those following
+  the repo. Any subsequent changes are not emailed, so it's worth spending a
+  bit of time getting it right at the point of raising the PR.
+- It is worth explaining/highlighting any potentially contentious changes, and
+  any testing that you have already done.
+
+Note: The canonical description of changes should always be in the individual
 commits - Pull Requests are an artefact of GitHub, and we would lose that data
 if we switched away. Please refer to the [commit message
 styleguide](/git.md#commit-messages).
-
-That said, the PR description is there to aid the reviewer and to help get your
-code merged - here are some guidelines to help with that process:
-
-- Before opening the PR, make sure you're up to date with `master` so that your
-  changes are easier to merge
-- Make the title of the PR scannable - this will ensure that it's easier for
-  potential reviewers to notice
-- Summarise your changes in the description - this aids both the reviewer and
-  any recipients of the PR via email
-- Title and description changes aren't sent out on notification emails etc., so
-  please ensure you've got a reasonable title and description *before* opening
-  the PR
-- Include information about the problem/user need/tracker ticket you're fixing
-  to help summarise the issue
-- If the changes involve frontend code, we love screenshots!
-- If your changes contain some potentially contentious changes, pre-empt these
-  by explaining why you went one way over another (for the benefit of the
-  reviewer and any watchers)
-- If the changes are difficult or hard to test, please include a summary of your
-  testing methodology and confidence level in the request - this will aid
-  reviewers and prevent them from doing the same work over (this particularly
-  applies to Infrastructure changes, but equally to database optimisations,
-  multi-app API changes etc.)
-- If there are several PRs that you would like to be reviewed and merged together
-  (eg frontend and backend changes, or endpoint and adapter changes), cross-link
-  the PRs by referencing the other PR in a comment or the PR description
 
 ### Reviewing a request
 

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -70,15 +70,12 @@ styleguide](/git.md#commit-messages).
   the changes required.
 - If you look at a PR but don't feel comfortable merging it please say what
   you've looked at or not so other reviewers know the request hasn't been
-  properly reviewed
+  properly reviewed.
 - Always comment on individual lines in the full-file diff view, not on a commit
   page because GitHub loses them if you rebase
 - If you're committed to reviewing the request through to merging or closing,
   assign the PR to yourself
-- If something is a blocker to merging, make that explicit by stating that it's
-  a blocker in a comment
-- Likewise, when commenting on things, state plainly whether the rest of the PR
-  is good to merge (to aid future mergers once comment is addressed)
+- State what, if anything, is a blocker explicitly
 - Ensure that any relevant documentation (`README` files, things in the `doc`
   folder) is up to date with the changes
 

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -2,7 +2,7 @@
 
 This is a pull requests style guide for working on GOV.UK.
 
-## Why do we do pull requests on GOV.UK?
+## Why we do pull requests on GOV.UK
 
 - It's good practice to have a second opinion
 - It's part of our accreditation - the extra pair of (unconnected - even if you
@@ -13,15 +13,13 @@ This is a pull requests style guide for working on GOV.UK.
   otherwise not be involved (we can even 'mention' specific people with `@name`
   syntax)
 
-## What shouldn't we do?
+## Cautionary notes
 
-- Use PRs for architectural review - this should be done before the PR with a
-  different audience
-- Consider our work to be 'done' when opening a PR - code is done when it's in
-  production
-- Rely on someone else to spot and merge your PR - it's your job to find a
+- Don't use PRs for architectural review - this should be done before the pull
+  request is raised
+- Don't rely on someone else to spot and merge your PR - it's your job to find a
   reviewer and get the code merged
-- Consider PRs to be all of the work - it's okay to have follow-up PRs for a
+- A PR doesn't have to be all of the work - it's okay to have follow-up PRs for a
   feature if a set of changes are complete enough to go live
 
 ## Guidance for each step

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -50,8 +50,8 @@ styleguide](/git.md#commit-messages).
 
 ### Reviewing a request
 
-Reviewing a request is just as important as writing the code in the first
-place - we need to create space and time to do this.
+- It is important to take time to review a pull request properly; the review
+  stage is as important as writing the code in the first place
 
 If you're not sure how the individual wants their request reviewed, make an
 effort to contact them before starting - they may prefer some of the feedback to

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -58,9 +58,6 @@ code merged - here are some guidelines to help with that process:
   reviewers and prevent them from doing the same work over (this particularly
   applies to Infrastructure changes, but equally to database optimisations,
   multi-app API changes etc.)
-- If you're changing documentation, always use a spell checker before pushing.
-  We don't always expect comments in code to be free of errors, but we hold
-  documentation to the same standard as anything else we publish
 - If there are several PRs that you would like to be reviewed and merged together
   (eg frontend and backend changes, or endpoint and adapter changes), cross-link
   the PRs by referencing the other PR in a comment or the PR description


### PR DESCRIPTION
The pull request guidance is currently very long. It contains useful information, but is too long to point people at; it is basically a wall of text.

This is a first stab at cutting it down to the crucial points so it can be a more useful resource. There is certainly more that could be done but I thought it worth making this first step. Explanation of all changes is in each commit message.

I've discussed my intention to do this offline with @daibach and I think it should probably be him who reviews this. Please note, Dai, that I am on leave from 6th January so won't respond to any comments after that; if you are looking at it after that point please feel free to make any changes you think are appropriate. 