### PR TITLE
Prefer blank lines around access modifiers

### DIFF
--- a/ruby.md
+++ b/ruby.md
@@ -547,10 +547,11 @@ This styleguide is based on [GitHub's](https://github.com/styleguide/ruby).
 
 -   Indent `public`, `protected`, and `private` methods to the same level as
     the rest of the methods. Outdent `private` etc. to the same level as
-    `class`, and leave one blank line before, none after. Outdenting these from
-    the method definitions helps them to stand out (syntax highlighting seems
-    to be unreliable in this case). Keeping private methods at the same depth
-    as other methods avoids complicating diffs.
+    `class`, and leave one blank line before  the visibility modifier and one
+    blank line below in order to emphasize that it applies to all methods below
+    it. Outdenting these from the method definitions helps them to stand out (
+    syntax highlighting seems to be unreliable in this case). Keeping private
+    methods at the same depth as other methods avoids complicating diffs.
 
     ```ruby
     class SomeClass


### PR DESCRIPTION
There's no cop available to enforce our current "blank line before, nothing after" rule so we can only enforce this using humans.  To reduce the burden we should change our guide to something that is enforcable by a cop (Style/EmptyLinesAroundAccessModifier) and is more in line with the global ruby community reckons expressed in https://github.com/bbatsov/ruby-style-guide#indent-public-private-protected.

Assuming we're happy with this, I'll raise a PR to enable the relevant cop in https://github.com/alphagov/govuk-lint