### PR TITLE
Guidance for calling methods with multiple args

### DIFF
--- a/ruby.md
+++ b/ruby.md
@@ -103,6 +103,28 @@ This styleguide is based on [GitHub's](https://github.com/styleguide/ruby).
     end
     ```
 
+-   When long lists of method arguments require breaking over multiple lines,
+    break each successive argument on a new line, including the first argument
+    and closing paren. The final argument should include a trailing comma.
+
+    ```ruby
+    # bad
+    some_method('first', 'second',
+                'another',
+                { something: 'nothing' })
+
+    # good
+    some_method(
+      'first',
+      'second',
+      'another',
+      { something: 'nothing' },
+    )
+
+    # good, doesn't need to span multiple lines
+    some_method('first', 'second')
+    ```
+
 ## Gemfile
 
 -   Where a gem is trusted to follow [semantic versioning](http://semver.org/),


### PR DESCRIPTION
I've noticed various styles being used throughout the projects and
wanted to try and settle upon some recognised style for calling methods
with multiple arguments spanning multiple lines. My preferred style is
the one described as `#good`. I know others prefer `#bad`.

My view is the `#good` style apes our guidance for literal arrays and
hashes and adds readability. Often what can happen is those arguments
are indented at the opening paren level and can be missed or obscured
for those of us with 80 (and for some measures greater) char terminals.

If this gets general approval, I'll add a cop to `alphagov/govuk-lint`
and revisit this guidance with a referral to said cop.