### PR TITLE
Clarify wording about Smart Answers in use-of-READMEs.md

### DIFF
--- a/use-of-READMEs.md
+++ b/use-of-READMEs.md
@@ -79,11 +79,11 @@ Keep this section limited to core endpoints - if the app is complex link out to 
 - Full documentation of the API - if the app is complex or has a complex API, use the `docs` directory liberally, and link out to it from the `README`
   - If the API is small try to keep it in the main README and don't link to docs
   - Some bad examples - too much documentation in the README:
-    - [smart-answers](https://github.com/alphagov/smart-answers/blob/06dfeb854ec9728374186a2e37c1eb62a5aaa49a/README.md)
+    - [smart-answers (older version)](https://github.com/alphagov/smart-answers/blob/06dfeb854ec9728374186a2e37c1eb62a5aaa49a/README.md)
     - [govuk_frontend_toolkit](https://github.com/alphagov/govuk_frontend_toolkit/blob/edd834de8d2f4e854475f5d226aa0cd260795cef/README.md)
   - Good examples:
     - [content-store](https://github.com/alphagov/content-store/blob/b244620f505f248fc93d8556eedad14b5cba1187/README.md) - links out to more docs as required
-    - [modern smart-answers](https://github.com/alphagov/smart-answers/blob/c0b4580d18ccc5004abfa7015017d26e1a73f2aa/README.md) - links out to more docs as required
+    - [smart-answers (newer version)](https://github.com/alphagov/smart-answers/blob/c0b4580d18ccc5004abfa7015017d26e1a73f2aa/README.md) - links out to more docs as required
   - For Ruby libraries always use [yardoc](http://yardoc.org/) - then Gems will automatically have docs built
 - Contributors - we can use GitHub's native graphing tools for this
 - Contribution guidelines - use GitHub's [CONTRIBUTING.md](https://help.github.com/articles/setting-guidelines-for-repository-contributors/) guidelines for this


### PR DESCRIPTION
This supersedes #87.

In the list of bad examples it wasn't obvious to me that the link to the Smart Answers README was for an old version of the app. The previous wording implied to me that the current version of the Smart Answer README is "bad" when it is not.

Likewise in the list of good examples, it wasn't obvious to me what "modern" Smart Answers meant.