### PR TITLE
Update example for GOVUK modules to be consistent with current codebase

### DIFF
--- a/js.md
+++ b/js.md
@@ -136,15 +136,20 @@ Modules should be wrapped in a closure and attach themselves to the global
 `GOVUK` object.
 
 ```
-(function() {
+(function(global) {
   "use strict";
-  window.GOVUK = window.GOVUK || {};
-  var $ = window.jQuery;
+
+  var $ = global.jQuery;
+  var GOVUK = global.GOVUK || {};
 
   ...
 
   GOVUK.myModule = ...
-}());
+
+  ...
+
+  global.GOVUK = GOVUK;
+})(window);
 ```
 
 **Why:** attaching to the `GOVUK` object keeps us from polluting the global


### PR DESCRIPTION
Updated to reflect @colinrotherham 's changes to enable support for module loaders.

https://github.com/alphagov/govuk_frontend_toolkit/pull/290

(Hopefully in the future we can remove this boilerplate in favour of a proper module system 🙌 )