### PR TITLE
Make guides more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GOV.UK Style guides
 
-This is a collection of styleguides for development of apps on GOV.UK.
+This is a collection of style guides for development of apps on GOV.UK.
 
 ## Languages
 

--- a/api.md
+++ b/api.md
@@ -1,6 +1,6 @@
-## API styleguide
+# API style guide
 
-### RESTful behaviour and HTTP status codes
+## RESTful behaviour and HTTP status codes
 
 - Use `202` for times when the data is valid, but we've queued the persistence for background processing, as described in [RFC 7231](http://tools.ietf.org/html/rfc7231#section-6.3.3):
 

--- a/css.md
+++ b/css.md
@@ -1,4 +1,4 @@
-## CSS Coding Style
+# CSS Coding Style
 
 ## Contents
 

--- a/go.md
+++ b/go.md
@@ -1,6 +1,6 @@
-# Go styleguide
+# Go style guide
 
-The purpose of this styleguide is to provide some conventions for working on Go code within GDS. There are already good resources on writing Go code, which are worth reading first:
+The purpose of this style guide is to provide some conventions for working on Go code within GDS. There are already good resources on writing Go code, which are worth reading first:
 
 * [Effective Go](https://golang.org/doc/effective_go.html)
 * [Code Review Comments](https://code.google.com/p/go-wiki/wiki/CodeReviewComments) (documenting points that have been raised in Google code reviews)

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -44,7 +44,7 @@ If you are not sure how to do any of this, please feel free to ask for help.
 Note: The canonical description of changes should always be in the individual
 commits - Pull Requests are an artefact of GitHub, and we would lose that data
 if we switched away. Please refer to the [commit message
-styleguide](/git.md#commit-messages).
+style guide](/git.md#commit-messages).
 
 ### Reviewing a request
 

--- a/ruby.md
+++ b/ruby.md
@@ -26,7 +26,7 @@ Some good reasons to ignore a particular guideline:
 
 The rules in this guide are annotated with their corresponding automated validators in Rubocop. Please see [using-rubocop](using-rubocop.md) for more information.
 
-This styleguide is based on [GitHub's](https://github.com/styleguide/ruby).
+This style guide is based on [GitHub's](https://github.com/styleguide/ruby).
 
 ## General
 

--- a/rubygems.md
+++ b/rubygems.md
@@ -1,3 +1,5 @@
+# Rubygems
+
 ## Naming
 
 In general, the gem name should be the same as the thing you require when using
@@ -48,5 +50,3 @@ An example `jenkins.sh`:
     bundle install --path "${HOME}/bundles/${JOB_NAME}"
     bundle exec rake
     bundle exec rake publish_gem
-
-

--- a/use-of-READMEs.md
+++ b/use-of-READMEs.md
@@ -87,7 +87,7 @@ Keep this section limited to core endpoints - if the app is complex link out to 
   - For Ruby libraries always use [yardoc](http://yardoc.org/) - then Gems will automatically have docs built
 - Contributors - we can use GitHub's native graphing tools for this
 - Contribution guidelines - use GitHub's [CONTRIBUTING.md](https://help.github.com/articles/setting-guidelines-for-repository-contributors/) guidelines for this
-  - When writing this document, always link to the [GOV.UK pull request styleguide](https://github.com/alphagov/styleguides/blob/master/pull-requests.md)
+  - When writing this document, always link to the [GOV.UK pull request style guide](https://github.com/alphagov/styleguides/blob/master/pull-requests.md)
   - Document any weirdness here (eg when to use Cucumber over something else)
 - Full licence - again, follow [GitHub convention](https://help.github.com/articles/open-source-licensing/#where-does-the-license-live-on-my-repository)
 

--- a/using-rubocop.md
+++ b/using-rubocop.md
@@ -8,7 +8,7 @@ Rubocop is an [open-source gem](https://github.com/bbatsov/rubocop) that perform
 
 Using Rubocop is not compulsory for GDS Ruby projects. It is however highly recommended to enforce at least consistent use of whitespace and indentation.
 
-The [govuk-lint](https://github.com/alphagov/govuk-lint) Gem includes Rubocop and Cops that correspond to the GDS Styleguide.
+The [govuk-lint](https://github.com/alphagov/govuk-lint) Gem includes Rubocop and Cops that correspond to the GDS style guide.
 
 ## How to setup Rubocop
 
@@ -17,7 +17,7 @@ The [govuk-lint](https://github.com/alphagov/govuk-lint) Gem includes Rubocop an
 
 ## Existing projects
 
-If you have an existing Ruby project that has a number of violations of the GDS styleguide, a way of addressing those issues is:
+If you have an existing Ruby project that has a number of violations of the GDS style guide, a way of addressing those issues is:
 
 1) Run ```govuk-lint-ruby --auto-correct``` in your project root, check that you are happy with those changes and commit.
 
@@ -25,7 +25,7 @@ If you have an existing Ruby project that has a number of violations of the GDS 
 
 ## Jenkins builds
 
-You may wish to use your project's Jenkins build to track whether more violations of the Ruby styleguide are being added to your project.
+You may wish to use your project's Jenkins build to track whether more violations of the Ruby style guide are being added to your project.
 For an example of how to set that up for a project, please see:
 
 * [whitehall](https://github.com/alphagov/whitehall/pull/2228)

--- a/using-rubocop.md
+++ b/using-rubocop.md
@@ -1,21 +1,21 @@
 # Using Rubocop
 
-##What is Rubocop
+## What is Rubocop
 
 Rubocop is an [open-source gem](https://github.com/bbatsov/rubocop) that performs static analysis of Ruby code according to rules that can be granularly configured. Each validation, or rule, is called a "cop". Some of those cops come with the ability to auto-correct issues.
 
-##Recommended usage
+## Recommended usage
 
 Using Rubocop is not compulsory for GDS Ruby projects. It is however highly recommended to enforce at least consistent use of whitespace and indentation.
 
 The [govuk-lint](https://github.com/alphagov/govuk-lint) Gem includes Rubocop and Cops that correspond to the GDS Styleguide.
 
-##How to setup Rubocop
+## How to setup Rubocop
 
 - add 'govuk-lint' to your Gemfile
 - you will now be able to run ```govuk-lint-ruby``` in your project root folder
 
-##Existing projects
+## Existing projects
 
 If you have an existing Ruby project that has a number of violations of the GDS styleguide, a way of addressing those issues is:
 
@@ -23,7 +23,7 @@ If you have an existing Ruby project that has a number of violations of the GDS 
 
 2) For the remainder of the violations, you'll need to manually fix the issues before committing the code containing those fixes.
 
-##Jenkins builds
+## Jenkins builds
 
 You may wish to use your project's Jenkins build to track whether more violations of the Ruby styleguide are being added to your project.
 For an example of how to set that up for a project, please see:

--- a/using-rubocop.md
+++ b/using-rubocop.md
@@ -1,3 +1,5 @@
+# Using Rubocop
+
 ##What is Rubocop
 
 Rubocop is an [open-source gem](https://github.com/bbatsov/rubocop) that performs static analysis of Ruby code according to rules that can be granularly configured. Each validation, or rule, is called a "cop". Some of those cops come with the ability to auto-correct issues.


### PR DESCRIPTION
This PR:

- Makes the guides use the words "style guide" consistently (rather than "styleguide")
- Fixes inconsistencies in the headings