### PR TITLE
Add licensing styleguide

### DIFF
--- a/licensing.md
+++ b/licensing.md
@@ -1,0 +1,27 @@
+# Licensing
+
+## Each repository should include a licence file
+
+This should be called `LICENCE` or `LICENCE.md`. "License" is the U.S. English spelling.
+
+GitHub.com will still show licence details for the British English spelling.
+
+## Use MIT
+
+At GDS we use the [MIT License](https://opensource.org/licenses/MIT).
+
+Make sure the licence content is included in full, including the title "The MIT License", so that readers are quickly able to see what licence is being used.
+
+## Copyright notice
+
+The Copyright is Crown Copyright; you can put "Government Digital Service" in brackets.
+
+e.g. `Copyright (c) 2017 Crown Copyright (Government Digital Service)`.
+
+The year should be the year the code was first published. Where the code is continually updated with significant changes, the year can be shown as a period from first to most recent update (e.g. 2015-2017).
+
+For more information on copyright notices, see the [UK Copyright Service fact sheet](http://www.copyrightservice.co.uk/copyright/p03_copyright_notice).
+
+## Example
+
+There is a good example of a licence in the [pay-adminusers](https://github.com/alphagov/pay-adminusers/blob/master/LICENCE) repo.


### PR DESCRIPTION
We made lots of updates a few years ago to make sure everything had Crown Copyright, and most of our repos have licence files, but we don't consistently do this correctly; for example some repositories do not include the title of the licence so you have to read all the text to be sure what it is.

This commit adds a styleguide to clarify what the licence should look like.