### PR TITLE
Change rubygems asciicast link to railscasts

### DIFF
--- a/rubygems.md
+++ b/rubygems.md
@@ -20,7 +20,7 @@ branches.
 ## File layout
 
 We should follow the scheme used by Bundler when creating gems (see [this
-asciicast](http://asciicasts.com/episodes/245-new-gem-with-bundler)).
+railscast](http://railscasts.com/episodes/245-new-gem-with-bundler?view=asciicast)).
 
 Some points to note:
 


### PR DESCRIPTION
The asciicast.com domain has lapsed, and has been bought by spammers.
Railscasts.com has the cast at the same path with a small addition to
the querystring.