### PR TITLE
Update 'git push -f' advice

### DIFF
--- a/git.md
+++ b/git.md
@@ -125,35 +125,23 @@ branch in the repository history. This advice may be freely ignored for smaller
 local feature branches for which a fast-forward merge will look like any other
 routine development work on `master`.
 
-## Never call `git push -f` without additional arguments
+## Don't use `git push -f`, use `--force-with-lease` instead
 
 Force pushing in git is a subject that attracts all kinds of religious
-battles. This advice is not about the merits of force pushing.
-
-This is about how to use `git push -f` if and when you do use it.
+battles. This advice is not about the merits of force pushing. This is about how
+to use `git push -f` if and when you do use it.
 
 Let's say you're working on a branch, 'foobar', and you decide to force push
 to the remote. So you do this:
 
     $ git push -f
 
-If anyone has committed anything to master[^1] since you last pulled -- and if
-you've been working on the branch for any length of time this is pretty likely
--- you will blow their changes away, because without arguments git will force
-push *all* remote-tracking branches.
+If anyone else has committed anything to your branch since you last pulled, you
+will blow their changes away.
 
-So, if you ever need to force push the 'foobar' branch, please instead do
+So for a bit of safety, if you ever need to force push please instead do:
 
-    $ git push --force-with-lease origin foobar
+    $ git push --force-with-lease
 
 `--force-with-lease` refuses to update a branch unless it is the state that we expect; i.e. nobody has updated the remote branch.
 See: https://developer.atlassian.com/blog/2015/04/force-with-lease/
-
-You can also change git's default behaviour of pushing all tracked branches by
-doing `git config --global push.default upstream`, but you should probably get
-into the habit of typing out your intentions in full when doing a destructive
-operation like force pushing, otherwise disaster will strike when you use
-someone else's differently-configured git, or miss a step when configuring a
-new machine.
-
-[^1]: (or any other remote-tracking branch you have in your local copy)


### PR DESCRIPTION
The default for 'git pushes' changed with git 2.0 in 2014, so it only pushes the current branch, not to others too:
https://stackoverflow.com/questions/13148066/warning-push-default-is-unset-its-implicit-value-is-changing-in-git-2-0
So you don't have to mention the branch name in modern times.

It seems such a rare occurrence anyone will come across a version of git older in their normal dev workflow, and if they do, they will suffer issues with all their pushes, not just force pushes. So let's optimize guidance for the common case, reducing the cognitive cost of reading for everyone, and be bold :)