### PR TITLE
remove stray `§` character

### DIFF
--- a/js.md
+++ b/js.md
@@ -37,7 +37,7 @@ Easier than running standard manually is to install it as a plugin in your edito
 There are [official guides for most of the popular editors](http://standardjs.com/index.html#text-editor-plugins).
 
 ### Why standard?
-§
+
 Linting rules can be a contentious subject, and a lot of them are down to personal preference. The core idea of standard is to be opinionated and limit the amount of initial bikeshedding discussions around which linting rules to pick, because in the end, it's not as important which rules you pick as it is to just be consistent about it. This is why we chose standard: because we want to be consistent about how we write code, but don't want to spend unnecessary time picking different rules (which all have valid points).
 
 The standard docs have a [complete list of rules and some reasoning behind them](http://standardjs.com/rules.html).


### PR DESCRIPTION
I thought it pointed to a footnote, but it didn't - so it's just confusing! I assume it slipped in by accident.