### PR TITLE
Adds deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**Deprecation notice: style guides have been moved to [The GDS Way](https://gds-way.cloudapps.digital/) and will no longer be maintained here.**
+
 # GOV.UK Style guides
 
 This is a collection of style guides for development of apps on GOV.UK.


### PR DESCRIPTION
Have ported over the style guides in https://github.com/alphagov/gds-way/pull/271.

On merge, we should archive the repository so that it becomes read-only.